### PR TITLE
Validate tokens against user revocation timestamp

### DIFF
--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/User.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/User.java
@@ -75,6 +75,9 @@ public class User implements UserDetails {
     @Builder.Default
     private Boolean credentialsNonExpired = true;
 
+    @Column(name = "tokens_revoked_at")
+    private LocalDateTime tokensRevokedAt;
+
     @Override
     public String getUsername() {
         return email;

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/AuthenticationService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/AuthenticationService.java
@@ -19,6 +19,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZoneId;
+import java.util.Date;
+
 /**
  * Service d'authentification refactorisé avec séparation claire des responsabilités
  * Utilise les services spécialisés pour JWT, refresh tokens et blacklist
@@ -213,7 +216,14 @@ public class AuthenticationService {
 
             // Vérifier si tous les tokens de l'utilisateur sont révoqués
             String userEmail = jwtService.extractEmail(token);
-            // TODO: Extraire issuedAt du token pour vérifier révocation globale
+            Date issuedAt = jwtService.extractIssuedAt(token);
+            User user = userService.findByEmail(userEmail);
+
+            if (user.getTokensRevokedAt() != null) {
+                if (issuedAt.toInstant().isBefore(user.getTokensRevokedAt().atZone(ZoneId.systemDefault()).toInstant())) {
+                    return false;
+                }
+            }
 
             return true;
 


### PR DESCRIPTION
## Summary
- verify access tokens against global revocation by comparing the token issue date to the user's `tokensRevokedAt`
- add `tokensRevokedAt` field to user entity to store global revocation time

## Testing
- `mvn -q -pl nexus-auth-server-2 -am test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689a7abc0fb08322b743766c62a35006