### PR TITLE
feat: require linked Discord and BattleNet accounts

### DIFF
--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/config/RestTemplateConfig.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/config/RestTemplateConfig.java
@@ -1,0 +1,18 @@
+package fr.kryptonn.nexus.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configuration simple pour exposer un {@link RestTemplate} réutilisable.
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}
+

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/config/SecurityConfig.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers("/.well-known/**", "/oauth2/jwks").permitAll()
                         .requestMatchers("/test/**").permitAll() //TODO: remove
                         .requestMatchers("/images/**", "/css/**", "/js/**", "/static/**").permitAll()
+                        .requestMatchers("/api/oauth/**").permitAll()
 
                         // Endpoints d'authentification
                         .requestMatchers("/auth/me/**", "/auth/logout/**").authenticated()

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/controller/OAuthController.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/controller/OAuthController.java
@@ -1,0 +1,60 @@
+package fr.kryptonn.nexus.auth.controller;
+
+import fr.kryptonn.nexus.auth.dto.LinkBattleNetDto;
+import fr.kryptonn.nexus.auth.dto.LinkDiscordDto;
+import fr.kryptonn.nexus.auth.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * Endpoints de rappel OAuth2 pour l'association des comptes externes.
+ */
+@RestController
+@RequestMapping("/api/oauth")
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthController {
+
+    private final UserService userService;
+
+    /**
+     * Callback OAuth2 pour Battle.net. Le paramètre state doit contenir l'identifiant utilisateur.
+     */
+    @GetMapping("/battlenet/callback")
+    public ResponseEntity<String> battleNetCallback(
+            @RequestParam("code") String code,
+            @RequestParam("state") String state,
+            HttpServletRequest request) {
+        log.debug("Réception du callback Battle.net pour l'utilisateur {}", state);
+        Long userId = Long.valueOf(state);
+        String redirectUri = ServletUriComponentsBuilder.fromCurrentRequest().build().toUriString();
+        userService.linkBattleNetAccount(userId, LinkBattleNetDto.builder()
+                .code(code)
+                .redirectUri(redirectUri)
+                .build());
+        return ResponseEntity.ok("Battle.net account linked");
+    }
+
+    /**
+     * Callback OAuth2 pour Discord. Le paramètre state doit contenir l'identifiant utilisateur.
+     */
+    @GetMapping("/discord/callback")
+    public ResponseEntity<String> discordCallback(
+            @RequestParam("code") String code,
+            @RequestParam("state") String state,
+            HttpServletRequest request) {
+        log.debug("Réception du callback Discord pour l'utilisateur {}", state);
+        Long userId = Long.valueOf(state);
+        String redirectUri = ServletUriComponentsBuilder.fromCurrentRequest().build().toUriString();
+        userService.linkDiscordAccount(userId, LinkDiscordDto.builder()
+                .code(code)
+                .redirectUri(redirectUri)
+                .build());
+        return ResponseEntity.ok("Discord account linked");
+    }
+}
+

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/controller/UserController.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/controller/UserController.java
@@ -1,6 +1,8 @@
 package fr.kryptonn.nexus.auth.controller;
 
 import fr.kryptonn.nexus.auth.dto.ChangePasswordDto;
+import fr.kryptonn.nexus.auth.dto.LinkBattleNetDto;
+import fr.kryptonn.nexus.auth.dto.LinkDiscordDto;
 import fr.kryptonn.nexus.auth.dto.UpdateUserDto;
 import fr.kryptonn.nexus.auth.dto.UserResponseDto;
 import fr.kryptonn.nexus.auth.service.UserService;
@@ -85,5 +87,23 @@ public class UserController {
         log.info("{} de l'utilisateur avec l'ID: {}", enabled ? "Activation" : "Désactivation", id);
         UserResponseDto updatedUser = userService.enableUser(id, enabled);
         return ResponseEntity.ok(updatedUser);
+    }
+
+    @PostMapping("/{id}/link/discord")
+    @PreAuthorize("hasRole('ADMIN') or authentication.principal.userId == #id")
+    public ResponseEntity<UserResponseDto> linkDiscord(
+            @PathVariable Long id,
+            @Valid @RequestBody LinkDiscordDto dto) {
+        log.info("Lien du compte Discord pour l'utilisateur {}", id);
+        return ResponseEntity.ok(userService.linkDiscordAccount(id, dto));
+    }
+
+    @PostMapping("/{id}/link/battlenet")
+    @PreAuthorize("hasRole('ADMIN') or authentication.principal.userId == #id")
+    public ResponseEntity<UserResponseDto> linkBattleNet(
+            @PathVariable Long id,
+            @Valid @RequestBody LinkBattleNetDto dto) {
+        log.info("Lien du compte Battle.net pour l'utilisateur {}", id);
+        return ResponseEntity.ok(userService.linkBattleNetAccount(id, dto));
     }
 }

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/LinkBattleNetDto.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/LinkBattleNetDto.java
@@ -1,0 +1,22 @@
+package fr.kryptonn.nexus.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * DTO utilisé pour lier un compte Battle.net à un utilisateur.
+ */
+@Data
+@Builder
+public class LinkBattleNetDto {
+
+    /** Code d'autorisation retourné par Battle.net après l'OAuth2. */
+    @NotBlank
+    private String code;
+
+    /** URI de redirection utilisée lors de l'authentification. */
+    @NotBlank
+    private String redirectUri;
+}
+

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/LinkDiscordDto.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/LinkDiscordDto.java
@@ -1,0 +1,22 @@
+package fr.kryptonn.nexus.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * DTO utilisé pour lier un compte Discord à un utilisateur.
+ */
+@Data
+@Builder
+public class LinkDiscordDto {
+
+    /** Code d'autorisation retourné par Discord après l'OAuth2. */
+    @NotBlank
+    private String code;
+
+    /** URI de redirection utilisée lors de l'authentification. */
+    @NotBlank
+    private String redirectUri;
+}
+

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/UserResponseDto.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/UserResponseDto.java
@@ -21,6 +21,8 @@ public class UserResponseDto {
     private LocalDateTime createdAt;
     private Set<String> authorities;
     private Boolean enabled;
+    private boolean discordLinked;
+    private boolean battleNetLinked;
 
     public static UserResponseDto fromUser(User user) {
         return UserResponseDto.builder()
@@ -28,6 +30,8 @@ public class UserResponseDto {
                 .email(user.getEmail())
                 .createdAt(user.getCreatedAt())
                 .enabled(user.getEnabled())
+                .discordLinked(user.getDiscordId() != null)
+                .battleNetLinked(user.getBattleNetId() != null)
                 .authorities(user.getAuthorities().stream()
                         .map(GrantedAuthority::getAuthority)
                         .collect(Collectors.toSet()))

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/User.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/User.java
@@ -78,6 +78,27 @@ public class User implements UserDetails {
     @Column(name = "tokens_revoked_at")
     private LocalDateTime tokensRevokedAt;
 
+    @Column(name = "discord_id")
+    private String discordId;
+
+    @Column(name = "discord_access_token")
+    private String discordAccessToken;
+
+    @Column(name = "discord_refresh_token")
+    private String discordRefreshToken;
+
+    @Column(name = "discord_token_expiry")
+    private LocalDateTime discordTokenExpiry;
+
+    @Column(name = "battlenet_id")
+    private String battleNetId;
+
+    @Column(name = "battlenet_access_token")
+    private String battleNetAccessToken;
+
+    @Column(name = "battlenet_token_expiry")
+    private LocalDateTime battleNetTokenExpiry;
+
     @Override
     public String getUsername() {
         return email;

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/repository/UserRepository.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/repository/UserRepository.java
@@ -52,6 +52,12 @@ public interface UserRepository extends JpaRepository<User, Long> { // ✅ Chang
             "WHERE a.authority = :authority")
     List<User> findByAuthority(@Param("authority") String authority);
 
+    Optional<User> findByDiscordId(String discordId);
+
+    Optional<User> findByBattleNetId(String battleNetId);
+
+    List<User> findByDiscordRefreshTokenIsNotNull();
+
     /**
      * ✅ Remplacé la requête native par JPQL pour éviter les problèmes de requête de comptage
      * Trouve les utilisateurs créés récemment (dernières 24h)

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/AuthenticationService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/AuthenticationService.java
@@ -103,7 +103,8 @@ public class AuthenticationService {
     public TokenPair generateTokenPair(String email) {
         try {
             // Générer access token
-            String accessToken = jwtService.generateAccessToken(email);
+            User user = userService.findByEmail(email);
+            String accessToken = jwtService.generateAccessToken(user);
 
             // Générer refresh token (avec rotation automatique)
             RefreshToken refreshToken = refreshTokenService.generateRefreshToken(email);
@@ -135,7 +136,8 @@ public class AuthenticationService {
             String userEmail = existingRefreshToken.getUser().getEmail();
 
             // Générer nouveau access token
-            String newAccessToken = jwtService.generateAccessToken(userEmail);
+            User user = userService.findByEmail(userEmail);
+            String newAccessToken = jwtService.generateAccessToken(user);
 
             // Rotation du refresh token pour sécurité
             RefreshToken newRefreshToken = refreshTokenService.rotateRefreshToken(existingRefreshToken);

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/BattleNetOAuthService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/BattleNetOAuthService.java
@@ -1,0 +1,79 @@
+package fr.kryptonn.nexus.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * Service utilitaire pour les échanges OAuth2 avec Battle.net.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BattleNetOAuthService {
+
+    @Value("${battlenet.client-id:}")
+    private String clientId;
+
+    @Value("${battlenet.client-secret:}")
+    private String clientSecret;
+
+    @Value("${battlenet.token-uri:https://oauth.battle.net/token}")
+    private String tokenUri;
+
+    @Value("${battlenet.user-info-uri:https://oauth.battle.net/oauth/userinfo}")
+    private String userInfoUri;
+
+    private final RestTemplate restTemplate;
+
+    /**
+     * Échange un code d'autorisation contre un token Battle.net.
+     */
+    public Map<String, Object> exchangeCode(String code, String redirectUri) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("grant_type", "authorization_code");
+        body.add("code", code);
+        body.add("redirect_uri", redirectUri);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        return restTemplate.postForObject(tokenUri, new HttpEntity<>(body, headers), Map.class);
+    }
+
+    /**
+     * Récupère l'identifiant Battle.net de l'utilisateur depuis le token d'accès.
+     */
+    public String fetchUserId(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        Map<String, Object> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                Map.class
+        ).getBody();
+        if (response != null) {
+            Object id = response.get("id");
+            if (id instanceof String s) {
+                return s;
+            }
+            if (id instanceof Number n) {
+                return String.valueOf(n.longValue());
+            }
+        }
+        return null;
+    }
+}

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/DiscordOAuthService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/DiscordOAuthService.java
@@ -1,0 +1,136 @@
+package fr.kryptonn.nexus.auth.service;
+
+import fr.kryptonn.nexus.auth.entity.User;
+import fr.kryptonn.nexus.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service gérant la régénération automatique des tokens Discord à partir du refresh token.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordOAuthService {
+
+    @Value("${discord.client-id:}")
+    private String clientId;
+
+    @Value("${discord.client-secret:}")
+    private String clientSecret;
+
+    @Value("${discord.token-uri:https://discord.com/api/oauth2/token}")
+    private String tokenUri;
+
+    @Value("${discord.user-info-uri:https://discord.com/api/users/@me}")
+    private String userInfoUri;
+
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate;
+
+    /**
+     * Échange un code d'autorisation contre des tokens Discord.
+     */
+    public Map<String, Object> exchangeCode(String code, String redirectUri) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("grant_type", "authorization_code");
+        body.add("code", code);
+        body.add("redirect_uri", redirectUri);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        return restTemplate.postForObject(tokenUri, new HttpEntity<>(body, headers), Map.class);
+    }
+
+    /**
+     * Récupère l'identifiant de l'utilisateur Discord à partir du token d'accès.
+     */
+    public String fetchUserId(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        Map<String, Object> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                Map.class
+        ).getBody();
+        if (response != null) {
+            Object id = response.get("id");
+            if (id instanceof String s) {
+                return s;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Vérifie régulièrement les tokens Discord et les régénère si nécessaire.
+     */
+    @Scheduled(fixedDelay = 300000) // Toutes les 5 minutes
+    public void refreshDiscordTokens() {
+        List<User> users = userRepository.findByDiscordRefreshTokenIsNotNull();
+        LocalDateTime now = LocalDateTime.now();
+
+        for (User user : users) {
+            if (user.getDiscordTokenExpiry() != null &&
+                    user.getDiscordTokenExpiry().isBefore(now.plusMinutes(5))) {
+                try {
+                    refreshToken(user);
+                } catch (Exception e) {
+                    log.warn("Erreur lors du rafraîchissement du token Discord pour {}: {}", user.getEmail(), e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Rafraîchit le token Discord d'un utilisateur.
+     */
+    public void refreshToken(User user) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("grant_type", "refresh_token");
+        body.add("refresh_token", user.getDiscordRefreshToken());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        Map<String, Object> response = restTemplate.postForObject(
+                tokenUri,
+                new HttpEntity<>(body, headers),
+                Map.class);
+
+        if (response != null) {
+            user.setDiscordAccessToken((String) response.get("access_token"));
+            Object refresh = response.get("refresh_token");
+            if (refresh instanceof String refreshStr) {
+                user.setDiscordRefreshToken(refreshStr);
+            }
+            Object expires = response.get("expires_in");
+            if (expires instanceof Number exp) {
+                user.setDiscordTokenExpiry(LocalDateTime.now().plusSeconds(exp.longValue()));
+            }
+            userRepository.save(user);
+            log.debug("Token Discord rafraîchi pour {}", user.getEmail());
+        }
+    }
+}
+

--- a/nexus-platform/nexus-auth-server-2/src/main/resources/application.yml
+++ b/nexus-platform/nexus-auth-server-2/src/main/resources/application.yml
@@ -104,6 +104,18 @@ app:
     access-expiration-ms: ${JWT_ACCESS_EXPIRATION_MS} # 15 minutes
     refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION_MS} # 7 jours
 
+discord:
+  client-id: ${DISCORD_CLIENT_ID}
+  client-secret: ${DISCORD_CLIENT_SECRET}
+  token-uri: https://discord.com/api/oauth2/token
+  user-info-uri: https://discord.com/api/users/@me
+
+battlenet:
+  client-id: ${BATTLENET_CLIENT_ID}
+  client-secret: ${BATTLENET_CLIENT_SECRET}
+  token-uri: https://oauth.battle.net/token
+  user-info-uri: https://oauth.battle.net/oauth/userinfo
+
 # Configuration Actuator pour monitoring
 management:
   endpoints:

--- a/nexus-platform/nexus-axon-app/src/main/java/fr/kryptonn/nexus/axon/config/SecurityConfig.java
+++ b/nexus-platform/nexus-axon-app/src/main/java/fr/kryptonn/nexus/axon/config/SecurityConfig.java
@@ -14,8 +14,10 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfigurationSource;
+import fr.kryptonn.nexus.axon.filter.LinkedAccountFilter;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -32,6 +34,7 @@ import java.util.Collection;
 public class SecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
+    private final LinkedAccountFilter linkedAccountFilter;
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
@@ -86,6 +89,8 @@ public class SecurityConfig {
                         // Tout le reste nécessite une authentification
                         .anyRequest().authenticated()
                 )
+
+                .addFilterAfter(linkedAccountFilter, BearerTokenAuthenticationFilter.class)
 
                 .build();
     }

--- a/nexus-platform/nexus-axon-app/src/main/java/fr/kryptonn/nexus/axon/filter/LinkedAccountFilter.java
+++ b/nexus-platform/nexus-axon-app/src/main/java/fr/kryptonn/nexus/axon/filter/LinkedAccountFilter.java
@@ -1,0 +1,42 @@
+package fr.kryptonn.nexus.axon.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Filtre vérifiant que l'utilisateur a bien lié ses comptes Discord et Battle.net
+ * avant d'accéder aux endpoints protégés de l'application Axon.
+ */
+@Component
+public class LinkedAccountFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken jwtAuth && authentication.isAuthenticated()) {
+            Boolean discordLinked = jwtAuth.getToken().getClaim("discordLinked");
+            Boolean battleNetLinked = jwtAuth.getToken().getClaim("battleNetLinked");
+
+            if (Boolean.FALSE.equals(discordLinked) || Boolean.FALSE.equals(battleNetLinked)) {
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\":\"LINK_REQUIRED\",\"message\":\"Discord et Battle.net doivent être liés\"}");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle Discord and Battle.net linking via OAuth2 code exchange
- add Battle.net OAuth service and expose provider settings
- persist linked account tokens and ids after OAuth completion

## Testing
- `mvn -q -pl nexus-auth-server-2,nexus-axon-app test` *(fails: Network is unreachable and parent POM could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689a851545f48322a82e96dbb8f27953