### PR TITLE
fix: correct redirect URI for OAuth callbacks

### DIFF
--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/controller/OAuthController.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/controller/OAuthController.java
@@ -31,7 +31,7 @@ public class OAuthController {
             HttpServletRequest request) {
         log.debug("Réception du callback Battle.net pour l'utilisateur {}", state);
         Long userId = Long.valueOf(state);
-        String redirectUri = ServletUriComponentsBuilder.fromCurrentRequest().build().toUriString();
+        String redirectUri = ServletUriComponentsBuilder.fromRequestUri(request).build().toUriString();
         userService.linkBattleNetAccount(userId, LinkBattleNetDto.builder()
                 .code(code)
                 .redirectUri(redirectUri)
@@ -49,7 +49,7 @@ public class OAuthController {
             HttpServletRequest request) {
         log.debug("Réception du callback Discord pour l'utilisateur {}", state);
         Long userId = Long.valueOf(state);
-        String redirectUri = ServletUriComponentsBuilder.fromCurrentRequest().build().toUriString();
+        String redirectUri = ServletUriComponentsBuilder.fromRequestUri(request).build().toUriString();
         userService.linkDiscordAccount(userId, LinkDiscordDto.builder()
                 .code(code)
                 .redirectUri(redirectUri)


### PR DESCRIPTION
## Summary
- avoid including query parameters in OAuth callback redirect URIs

## Testing
- `mvn -q -pl nexus-auth-server-2 -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d35af96f8832288d8029de89a4831