### PR TITLE
refactor: extract account details into embedded objects

### DIFF
--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/BattleNetAccount.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/BattleNetAccount.java
@@ -1,0 +1,30 @@
+package fr.kryptonn.nexus.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Informations de base pour un compte Battle.net lié
+ */
+@Embeddable
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BattleNetAccount {
+
+    @Column(name = "battlenet_id")
+    private String id;
+
+    @Column(name = "battlenet_access_token")
+    private String accessToken;
+
+    @Column(name = "battlenet_token_expiry")
+    private LocalDateTime tokenExpiry;
+}

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/DiscordAccount.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/DiscordAccount.java
@@ -1,0 +1,33 @@
+package fr.kryptonn.nexus.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Informations de base pour un compte Discord lié
+ */
+@Embeddable
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordAccount {
+
+    @Column(name = "discord_id")
+    private String id;
+
+    @Column(name = "discord_access_token")
+    private String accessToken;
+
+    @Column(name = "discord_refresh_token")
+    private String refreshToken;
+
+    @Column(name = "discord_token_expiry")
+    private LocalDateTime tokenExpiry;
+}

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/User.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/entity/User.java
@@ -78,26 +78,11 @@ public class User implements UserDetails {
     @Column(name = "tokens_revoked_at")
     private LocalDateTime tokensRevokedAt;
 
-    @Column(name = "discord_id")
-    private String discordId;
+    @Embedded
+    private DiscordAccount discordAccount;
 
-    @Column(name = "discord_access_token")
-    private String discordAccessToken;
-
-    @Column(name = "discord_refresh_token")
-    private String discordRefreshToken;
-
-    @Column(name = "discord_token_expiry")
-    private LocalDateTime discordTokenExpiry;
-
-    @Column(name = "battlenet_id")
-    private String battleNetId;
-
-    @Column(name = "battlenet_access_token")
-    private String battleNetAccessToken;
-
-    @Column(name = "battlenet_token_expiry")
-    private LocalDateTime battleNetTokenExpiry;
+    @Embedded
+    private BattleNetAccount battleNetAccount;
 
     @Override
     public String getUsername() {
@@ -153,5 +138,82 @@ public class User implements UserDetails {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getDiscordId() {
+        return discordAccount != null ? discordAccount.getId() : null;
+    }
+
+    public void setDiscordId(String discordId) {
+        if (discordAccount == null) {
+            discordAccount = new DiscordAccount();
+        }
+        discordAccount.setId(discordId);
+    }
+
+    public String getDiscordAccessToken() {
+        return discordAccount != null ? discordAccount.getAccessToken() : null;
+    }
+
+    public void setDiscordAccessToken(String token) {
+        if (discordAccount == null) {
+            discordAccount = new DiscordAccount();
+        }
+        discordAccount.setAccessToken(token);
+    }
+
+    public String getDiscordRefreshToken() {
+        return discordAccount != null ? discordAccount.getRefreshToken() : null;
+    }
+
+    public void setDiscordRefreshToken(String token) {
+        if (discordAccount == null) {
+            discordAccount = new DiscordAccount();
+        }
+        discordAccount.setRefreshToken(token);
+    }
+
+    public LocalDateTime getDiscordTokenExpiry() {
+        return discordAccount != null ? discordAccount.getTokenExpiry() : null;
+    }
+
+    public void setDiscordTokenExpiry(LocalDateTime expiry) {
+        if (discordAccount == null) {
+            discordAccount = new DiscordAccount();
+        }
+        discordAccount.setTokenExpiry(expiry);
+    }
+
+    public String getBattleNetId() {
+        return battleNetAccount != null ? battleNetAccount.getId() : null;
+    }
+
+    public void setBattleNetId(String id) {
+        if (battleNetAccount == null) {
+            battleNetAccount = new BattleNetAccount();
+        }
+        battleNetAccount.setId(id);
+    }
+
+    public String getBattleNetAccessToken() {
+        return battleNetAccount != null ? battleNetAccount.getAccessToken() : null;
+    }
+
+    public void setBattleNetAccessToken(String token) {
+        if (battleNetAccount == null) {
+            battleNetAccount = new BattleNetAccount();
+        }
+        battleNetAccount.setAccessToken(token);
+    }
+
+    public LocalDateTime getBattleNetTokenExpiry() {
+        return battleNetAccount != null ? battleNetAccount.getTokenExpiry() : null;
+    }
+
+    public void setBattleNetTokenExpiry(LocalDateTime expiry) {
+        if (battleNetAccount == null) {
+            battleNetAccount = new BattleNetAccount();
+        }
+        battleNetAccount.setTokenExpiry(expiry);
     }
 }

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/repository/UserRepository.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/repository/UserRepository.java
@@ -52,11 +52,11 @@ public interface UserRepository extends JpaRepository<User, Long> { // ✅ Chang
             "WHERE a.authority = :authority")
     List<User> findByAuthority(@Param("authority") String authority);
 
-    Optional<User> findByDiscordId(String discordId);
+    Optional<User> findByDiscordAccount_Id(String discordId);
 
-    Optional<User> findByBattleNetId(String battleNetId);
+    Optional<User> findByBattleNetAccount_Id(String battleNetId);
 
-    List<User> findByDiscordRefreshTokenIsNotNull();
+    List<User> findByDiscordAccount_RefreshTokenIsNotNull();
 
     /**
      * ✅ Remplacé la requête native par JPQL pour éviter les problèmes de requête de comptage

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/DiscordOAuthService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/DiscordOAuthService.java
@@ -85,7 +85,7 @@ public class DiscordOAuthService {
      */
     @Scheduled(fixedDelay = 300000) // Toutes les 5 minutes
     public void refreshDiscordTokens() {
-        List<User> users = userRepository.findByDiscordRefreshTokenIsNotNull();
+        List<User> users = userRepository.findByDiscordAccount_RefreshTokenIsNotNull();
         LocalDateTime now = LocalDateTime.now();
 
         for (User user : users) {


### PR DESCRIPTION
## Summary
- introduce DiscordAccount and BattleNetAccount embeddables to encapsulate external account data
- refactor User entity to embed account objects and provide helper accessors
- adjust repository and services for new account structure

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d38b4c17c8322a05b202db68ae6c9