### PR TITLE
Align login token expiry with Battle.net and enforce account linking

### DIFF
--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/UserResponseDto.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/dto/UserResponseDto.java
@@ -2,6 +2,7 @@ package fr.kryptonn.nexus.auth.dto;
 
 import fr.kryptonn.nexus.auth.entity.Authority;
 import fr.kryptonn.nexus.auth.entity.User;
+import fr.kryptonn.nexus.auth.entity.UserStatePhase;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
@@ -23,6 +24,7 @@ public class UserResponseDto {
     private Boolean enabled;
     private boolean discordLinked;
     private boolean battleNetLinked;
+    private UserStatePhase statePhase;
 
     public static UserResponseDto fromUser(User user) {
         return UserResponseDto.builder()
@@ -32,6 +34,7 @@ public class UserResponseDto {
                 .enabled(user.getEnabled())
                 .discordLinked(user.getDiscordId() != null)
                 .battleNetLinked(user.getBattleNetId() != null)
+                .statePhase(user.getStatePhase())
                 .authorities(user.getAuthorities().stream()
                         .map(GrantedAuthority::getAuthority)
                         .collect(Collectors.toSet()))

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/AuthenticationService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/AuthenticationService.java
@@ -87,6 +87,7 @@ public class AuthenticationService {
             );
 
             User user = userService.findByEmail(input.getEmail());
+            user = userService.updatePhaseAfterLogin(user);
             log.info("Connexion réussie pour l'utilisateur: {}", user.getEmail());
 
             return user;
@@ -114,7 +115,7 @@ public class AuthenticationService {
             return TokenPair.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken.getToken())
-                    .accessTokenExpiresIn(jwtService.getAccessTokenExpirationMs())
+                    .accessTokenExpiresIn(jwtService.getAccessTokenExpirationMs(user))
                     .refreshTokenExpiresIn(refreshTokenService.getRefreshTokenExpirationMs())
                     .build();
 
@@ -147,7 +148,7 @@ public class AuthenticationService {
             return TokenPair.builder()
                     .accessToken(newAccessToken)
                     .refreshToken(newRefreshToken.getToken())
-                    .accessTokenExpiresIn(jwtService.getAccessTokenExpirationMs())
+                    .accessTokenExpiresIn(jwtService.getAccessTokenExpirationMs(user))
                     .refreshTokenExpiresIn(refreshTokenService.getRefreshTokenExpirationMs())
                     .build();
 

--- a/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/UserService.java
+++ b/nexus-platform/nexus-auth-server-2/src/main/java/fr/kryptonn/nexus/auth/service/UserService.java
@@ -73,6 +73,26 @@ public class UserService {
     }
 
     /**
+     * Met à jour la phase de l'utilisateur en fonction des comptes liés
+     */
+    public User updatePhaseAfterLogin(User user) {
+        UserStatePhase target;
+        if (user.getDiscordId() != null && user.getBattleNetId() != null) {
+            target = UserStatePhase.COMPLETED;
+        } else if (user.getDiscordId() != null) {
+            target = UserStatePhase.BATTLE_NET_LINKING;
+        } else {
+            target = UserStatePhase.DISCORD_LINKING;
+        }
+
+        if (user.getStatePhase() != target) {
+            user.setStatePhase(target);
+            return save(user);
+        }
+        return user;
+    }
+
+    /**
      * Récupère tous les utilisateurs
      */
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- synchronize access token lifespan with Battle.net token expiry
- track account linking phase on login and expose phase in user response

## Testing
- `mvn -q -pl nexus-auth-server-2 -am test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d476eac2483229c137c4574f1a322